### PR TITLE
Add JRuby support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ group :development do
   gem "shoulda", ">= 0"
   gem "rspec"
 
-  gem "bundler", "~> 1.0.0"
   gem "watchr"
 end
 
@@ -20,6 +19,6 @@ end
 #
 group :test do
   gem "sequel"
-  gem "mysql"
-  gem "sqlite3"
+  gem "sqlite3", :platform => :ruby
+  gem "jdbc-sqlite3", :platform => :jruby
 end

--- a/lib/namey.rb
+++ b/lib/namey.rb
@@ -1,6 +1,6 @@
 module Namey
   def self.db_path
-    @@db_path ||= "sqlite://#{File.join(self.libdir, "..", "data", "names.db")}"  
+    @@db_path ||= "#{'jdbc:' if RUBY_PLATFORM == 'java'}sqlite://" + File.join(self.libdir, "..", "data", "names.db")
   end
   def self.db_path=(x)
     @@db_path = x

--- a/namey.gemspec
+++ b/namey.gemspec
@@ -5,7 +5,6 @@ require "namey/version"
 Gem::Specification.new do |s|
   s.name        = "namey"
   s.version     = Namey::VERSION
-  s.platform    = Gem::Platform::RUBY
   s.authors     = ["Colin Mitchell"]
   s.email       = ["colin@muffinlabs.com"]
   s.homepage    = "https://github.com/muffinista/namey"
@@ -19,23 +18,31 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
+  if RUBY_PLATFORM == "java"
+    s.platform = "java"
+    sqlite = "jdbc-sqlite3"
+  else
+    s.platform = Gem::Platform::RUBY
+    sqlite = "sqlite3"
+  end
+
   if s.respond_to? :specification_version then
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<sequel>, [">= 0"])
-      s.add_runtime_dependency(%q<sqlite3>, [">= 0"])
+      s.add_runtime_dependency(sqlite, [">= 0"])
       s.add_development_dependency(%q<shoulda>, [">= 0"])
       s.add_development_dependency(%q<yard>, [">= 0"])      
     else
       s.add_dependency(%q<sequel>, [">= 0"])
-      s.add_dependency(%q<sqlite3>, [">= 0"])      
+      s.add_dependency(sqlite, [">= 0"])
       s.add_dependency(%q<shoulda>, [">= 0"])
       s.add_dependency(%q<yard>, [">= 0"])
     end
   else
     s.add_dependency(%q<sequel>, [">= 0"])
-    s.add_dependency(%q<sqlite3>, [">= 0"])    
+    s.add_dependency(sqlite, [">= 0"])
     s.add_dependency(%q<shoulda>, [">= 0"])
     s.add_dependency(%q<yard>, [">= 0"])
   end

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
 describe "Namey::Generator" do
   before(:each) do
-    @uri = "sqlite:/"
+    @uri = "#{'jdbc:' if RUBY_PLATFORM == 'java'}sqlite:/"
     @gen = Namey::Generator.new(@uri)
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,6 @@ Bundler.require
 #require 'chatterbot'
 
 require 'tempfile'
-require 'sqlite3'
 
 
 # Requires supporting files with custom matchers and macros, etc,


### PR DESCRIPTION
JRuby uses jdbc-sqlite3 rather than sqlite3 and the connection string needs to be prefixed with jdbc:. Explicitly requiring sqlite3 is not necessary as Sequel does this automatically. JRuby doesn't have bundler ~> 1.0.0 and putting bundler in your Gemfile is redundant anyway. mysql has also been removed from the Gemfile because it is only used within the api directory, which has its own Gemfile. The presence of a gemspec may make the rest of this Gemfile redundant too but that it outside the scope of supporting JRuby.
